### PR TITLE
fix: replaced  old OSCA github  organisation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ After raising an Issue, you would receive a response from the project maintainer
 - [Git/ Git Hub on Windows](https://www.youtube.com/watch?v=J_Clau1bYco)
 
 
-For a complete guide on contributing, please visit our [resources](https://github.com/oscommunityafrica/docs).
+For a complete guide on contributing, please visit our [resources](https://github.com/oscafrica/docs).
 
 ## Versioning
 

--- a/community.html
+++ b/community.html
@@ -136,7 +136,7 @@
                                 It typically consists of a group of people coming together to
                                 organize and facilitate meetups, creating an environment of support in possible areas
                                 of challenge while following the <a style="color:#000"
-                                    href="https://github.com/oscommunityafrica/docs/blob/master/OSCA%20Code%20of%20Conduct.md">O.S.C.A
+                                    href="https://github.com/oscafrica/docs/blob/master/OSCA%20Code%20of%20Conduct.md">O.S.C.A
                                     Code of Conduct</a>.
                             </p>
                             <br />

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
           <span class="image"> <img src="images/pic02.jpg" alt="descriptive text" /> </span>
           <header class="major">
             <h3 style="text-transform:uppercase;">
-              <a href="https://github.com/oscommunityafrica" class="link">Projects</a>
+              <a href="https://github.com/oscafrica" class="link">Projects</a>
             </h3>
             <p>
               Do you want to feel the thrill of contributing? If yes, get on
@@ -161,7 +161,7 @@
           <span class="image"> <img src="images/pic04.jpg" alt="" /> </span>
           <header class="major">
             <h3 style="text-transform:uppercase;">
-              <a href="https://github.com/oscommunityafrica/docs" class="link">OSCA Documentation</a>
+              <a href="https://github.com/oscafrica/docs" class="link">OSCA Documentation</a>
             </h3>
             <p>
               Onboarding Resources for contributors, members and chapter
@@ -173,7 +173,7 @@
           <span class="image"> <img src="images/pic05.jpg" alt="" /> </span>
           <header class="major">
             <h3 style="text-transform:uppercase;">
-              <a href="https://github.com/oscommunityafrica/made-in-nigeria" target="_blank" class="link">Made In
+              <a href="https://github.com/oscafrica/made-in-nigeria" target="_blank" class="link">Made In
                 Africa</a>
             </h3>
             <p>


### PR DESCRIPTION
This PR replaces all old OSCA GitHub organisation links [https://github.com/oscommunityafrica](https://github.com/oscommunityafrica) with the updated organisation link [https://github.com/oscafrica](https://github.com/oscafrica),

Also a fix for #52, #53 and #54 .